### PR TITLE
Version bumps for HUnit and cereal

### DIFF
--- a/murmur3.cabal
+++ b/murmur3.cabal
@@ -27,7 +27,7 @@ library
 
     build-depends: base                     >= 4.6        && < 5 
                  , bytestring               >= 0.10       && < 0.11 
-                 , cereal                   >= 0.5.1      && < 0.5.2 
+                 , cereal                   >= 0.5.1      && < 0.5.3
 
     ghc-options: -Wall
 
@@ -41,7 +41,7 @@ test-suite test-murmur3
                  , base16-bytestring              >= 0.1        && < 1.2
                  , bytestring                     >= 0.10       && < 0.11 
                  , murmur3
-                 , HUnit                          >= 1.2        && < 1.3
+                 , HUnit                          >= 1.2        && < 1.4
                  , QuickCheck                     >= 2.6        && < 2.9
                  , test-framework                 >= 0.8        && < 0.9 
                  , test-framework-quickcheck2     >= 0.3        && < 0.4 


### PR DESCRIPTION
This is so that everything builds on GHC 8
