### PR TITLE
Update Units.hs

### DIFF
--- a/murmur3.cabal
+++ b/murmur3.cabal
@@ -40,7 +40,7 @@ test-suite test-murmur3
     other-modules: Data.Hash.Murmur.Units
 
     build-depends: base                           >= 4.6 && < 5 
-                 , base16-bytestring              >= 0.1
+                 , base16-bytestring              >= 1.0
                  , bytestring                     >= 0.10
                  , murmur3
                  , HUnit                          >= 1.2

--- a/tests/Data/Hash/Murmur/Units.hs
+++ b/tests/Data/Hash/Murmur/Units.hs
@@ -26,7 +26,7 @@ assertTestVector :: TestVector -> Assertion
 assertTestVector (expected, seed, str) =
     assertBool "    > MurmurHash3 " $ result == expected
   where
-    result = murmur3 seed (fst $ B16.decode $ C.pack str)
+    result = murmur3 seed (either error id $ B16.decode $ C.pack str)
 
 testVectors :: [TestVector]
 testVectors =


### PR DESCRIPTION
Fix call to base16-bytestring `decode`.

Tests do not compile. Commit to base16-bytestring changed the `decode` api:
https://github.com/haskell/base16-bytestring/commit/17ac911db01ad86ce52024f11104bde13d894c5a#diff-fb391de908a1daf3c09506e4104b2ebc92fd19c6684d09f0efa7e961069137da